### PR TITLE
Fixed login bug.

### DIFF
--- a/cmd/login.go
+++ b/cmd/login.go
@@ -255,10 +255,13 @@ func verify(url, email, token string) (string, error) {
 	}
 
 	//Handle Error
+	// Empty body means unconfirmed email, no error and no result
 	if response.Error.Code == "invalid_verification_token" {
 		return "", errors.New("your verification token is invalid")
 	} else if response.Error.Code == "server_not_available" {
 		return "", errors.New("service unavailable")
+	} else if len(body) == 0 {
+		return "", nil
 	}
 
 	return "", err


### PR DESCRIPTION
When attempting to login, I would get this error (in debug mode):

**[DEBUG] unexpected end of JSON input**
**[ERROR] login verification failed**

When the email is not confirmed, the post request returns an empty body which raises an error, preventing the timer from re-running and effectively stopping the login process.

I simply made it so that when the body is empty, it returns both an empty response and a nil error, allowing the timer to re-run.

